### PR TITLE
Rubicon: Migrating Adapter + new version

### DIFF
--- a/rubicon/CHANGES.md
+++ b/rubicon/CHANGES.md
@@ -1,0 +1,20 @@
+# 2.1.4
+ 
+- Testing file:
+the test file has been added with 8 tests and 8 success (system-tester.html).
+npm run debug  and reach /system-tester.html
+result: 8 specs, 0 failures
+ 
+- ESLint:
+Adapter file has been cleaned and succesfuly pass:
+npm run lint
+
+- Adapter changes:
+Some edit to change the rubicon key (hb_pb_ixrubicon) for reporting only.
+The ad is still correctly displayed on both the safeFrame and no safeFrame slots
+2 sizes have been added to the sizeToSizeIdMapping
+ 
+# 2.1.3
+ 
+Previous version used.
+

--- a/rubicon/DOCUMENTATION.md
+++ b/rubicon/DOCUMENTATION.md
@@ -1,0 +1,69 @@
+# Rubicon
+## General Compatibility
+|Feature|  |
+|---|---|
+| Consent |  |
+| Native Ad Support |  |
+| SafeFrame Support |  |
+| PMP Support | |
+ 
+## Browser Compatibility
+| Browser |  |
+|--- |---|
+| Chrome |  |
+| Edge |  |
+| Firefox |  |
+| Internet Explorer 9 |  |
+| Internet Explorer 10 |  |
+| Internet Explorer 11 |  |
+| Safari |  |
+| Mobile Chrome | |
+| Mobile Safari | |
+| UC Browser | |
+| Samsung Internet | |
+| Opera | |
+ 
+## Adapter Information
+| Info | |
+|---|---|
+| Partner Id | RubiconHtb |
+| Ad Server Responds in (Cents, Dollars, etc) | |
+| Bid Type (Gross / Net) | |
+| GAM Key (Open Market) | |
+| GAM Key (Private Market) | |
+| Ad Server URLs | |
+| Slot Mapping Sytle (Size / Multiple Sizes / Slot) | |
+| Request Architecture (MRA / SRA) | |
+ 
+## Currencies Supported
+ 
+## Bid Request Information
+### Parameters
+| Key | Required | Type | Description |
+|---|---|---|---|
+| | | | |
+ 
+### Example
+```javascript
+ 
+```
+ 
+## Bid Response Information
+### Bid Example
+```javascript
+ 
+```
+### Pass Example
+```javascript
+ 
+```
+ 
+## Configuration Information
+### Configuration Keys
+| Key | Required | Type | Description |
+|---|---|---|---|
+| | | | |
+### Example
+```javascript
+ 
+```

--- a/rubicon/README.md
+++ b/rubicon/README.md
@@ -1,0 +1,465 @@
+# Table of Contents
+1. [Introduction](#intro)
+    * [Repository Structure](#Repository)
+    * [Getting Started](#gettingStarted)
+2. [Requirements](#requirements)
+3. [Partner Module Overview](#overview)
+    * [Configuration](#configuration)
+    * [Event Model](#eventModel)
+    * [Creating a Partner Module](#creatingPartnerModule)
+4. [Utility Libraries](#helpers)
+    * [Utils](#utils)
+    * [BidRoundingTransformer](#bidRounding)
+5. [Linting](#linting)
+6. [Debugging](#debugging)
+7. [Testing](#testing)
+8. [Code Submission Guidelines](#codeSubmissionGuidelines)
+
+# <a name='intro'></a>Introduction
+
+<b>Welcome to the Index Exchange Partner Certification Process!</b>
+
+Below you will find everything you need to complete the certification process and be a part of the Header Tag Wrapper!
+
+## <a name='Repository'></a>Repository Structure
+* `README.md` - This is the main documentation file which should contain everything you need to complete the certification process. If anything is unclear, please refer to this document first.
+* `rubicon-htb.js` - This is your partner module file, by default it contains a template divided into multiple sections which need to be completed.
+* `rubicon-htb-validator.js` - This is the validator file for the configuration object that will be passed into your module.
+* `rubicon-htb-exports.js` - A file that contains all of the modules exports (i.e. any functions that need to be exposed to the outside world).
+
+## <a name='gettingStarted'></a>Getting Started
+1. <b>Complete the rubicon-htb.js file</b>
+    * rubicon-htb.js is where all of your adapter code will live.
+    * In order to complete the partner module correctly, please refer to the [Partner Module Overview](#overview) and the [Utility Libraries](#helpers) sections.
+    * <b>Please refer to the [Partner Requirements and Guidelines](#requirements) when creating your module. Ensure requirements are met to streamline the review process.</b>
+2. <b>Complete the rubicon-htb-validator.js file</b>
+    * This file is where your partner-specific configurations will need to be validated.
+    * Things like type and null checks will be done here.
+3. <b>Complete the rubicon-htb-exports.js file</b>
+    * This file will contain any functions that need to be exported or exposed to the outside world. Things like render functions, custom callbacks, etc. Any legacy render functions will also need to be exposed here. Anything added to the `shellInterface.RubiconHtb` will be accessible through `window.headertag.RubiconHtb`
+4. <b>Submitting for Review</b>
+    * Once the module has been verified submit a pull request from the `development-v2`branch to the `master-v2` branch for the Index Exchange team to review. If everything is approved, your adapter will be officially certified!
+
+# <a name='requirements'></a> Partner Requirements & Guidelines
+In order for your module to be successfully certified, please refer to the following list of requirements and guidelines. Items under required <b><u>must</b></u> be satisfied in order to pass the certification process. Items under guidelines are recommended for an optimal setup and should be followed if possible.
+
+### General
+
+#### Required
+* The only targeting keys that can be set are predetermined by Index. The partner module should not be setting targeting on other keys.
+* Must support the following browsers: IE 9+, Edge, Chrome, Safari, and Firefox
+* Must run system tests in all supported browsers
+* Must not use polyfills
+
+#### Recommended
+* Please use our helper libraries when possible. Refer to our [Utility Libraries](#helpers) documentation below. All of the utility functions in this library are designed to be backwards compatible with supported browsers to ease cross-browser compatibility.
+
+### Bid Request Endpoint
+
+#### Required
+* Must provide cache busting parameter. Cache busting is required to prevent network caches.
+* Partner endpoint domain must be consistent. Load balancing should be performed by the endpoint.
+* Your endpoint should support HTTPS request. When wrapper loads in secure pages, all requests need to be HTTPS. If you're unable to provide a secure endpoint, we will not be able to make requests to your ad servers.
+
+#### Recommended
+* Your module should support a single request architecture (SRA) which has a capability to send multiple bid requests in a single HTTP request.
+* Partner should use AJAX method to make bid requests. Please use our [Network](#network) utility library for making network requests, particularly the `Network.ajax` method. This ensures the requests will work with all browsers.
+
+### Bid Response
+
+#### Required
+* Returned bid must be a <b>net</b> bid.
+* Pass on bid must be explicit in the response.
+* All returned bids shall be in the currency trafficked by the publisher.
+* Size must be returned in the response. The sizes must also match the requested size. This size parameter will be validated.
+* Encrypted prices must be flagged in the response.
+
+### Pixels & Tracking Beacons
+
+#### Required
+* Pixels/beacons must only be dropped only when the partner wins the auction and their ad renders.
+* Dropping pixels during auction slows down the execution of auctions and is not allowed by Index Exchange.
+
+### DFP Setup
+
+#### Required
+* DFP line items, creatives, and render functions will be set up by the Index Exchange team.
+<br><br>
+
+# <a name='overview'></a> Partner Module Overview
+
+## <a name='configuration'></a>Prelude: Configuration & Parcels
+
+The Header Tag Wrapper passes each partner a configuration object that has been configured based on a publisher's website. This object contains all the configuration information required for the wrapper, including partner-specific slot mappings, timeouts, and any other partner-specific configuration.
+The partner-specific slot mappings dictate how ad slots on the page will map to partner-specific configuration.
+There are 2 concepts to be familiar with when understanding how slots on the page are mapped back to partner-specific configuration. Header Tag Slots, which refers to htSlots and partner-specific configuration, which refers to xSlots in the codebase.
+* htSlots - This is an abstraction of the googletag.slot object.
+  * These will need to be mapped to xSlots.
+* xSlots - These are also an abstraction for partner-specific configuration that will be mapped to htSlots.
+  * These represent a single partner-specific configuration.
+  * An xSlot is how a partner can map their ad server specific identifiers (placementIDs, siteIDs, zoneIDs, etc) to the `htSlot` object.
+  * It can represent a single or multiple sizes.
+  * Multiple xSlots can be mapped to the same htSlot.
+
+Example Partner Configuration Mapping
+```javascript
+{
+    "partners": {
+        "RubiconHtb": {
+            "enabled": true,
+            "configs": {
+                "xSlots": {
+                    "xSlot1": {
+                        "placementID": "123",
+                        "sizes": [ [300, 250], [300, 600] ]
+                    },
+                    "xSlot2": {
+                        "placementID": "345",
+                        "sizes": [ [300, 250] ]
+                    }
+                },
+                "mapping": {
+                    "htSlotID-1": [ "xSlot1" ],
+                    "htSlotID-2": [ "xSlot2" ]
+                }
+            }
+        }
+    }
+}
+```
+
+Based on the mapping defined in the partner config, <i>Parcels</i> will be generated for every xSlot/htSlot pair. Parcels are objects that carry different kinds of information throughout the wrapper. In the context of the adapter, parcels are the input into your adapter. Parcels carry information regarding which slots on the publisher's page need demand. More specifically parcels contain information like xSlot reference, htSlot references, demand (after its been applied by the adapter in parseResponse), etc. Each parcel represents a single combination of an htSlot and an xSlot.
+
+Each parcel is an object in the following form:
+
+```javascript
+{
+    "partnerId": "RUBI",
+    "htSlot": {
+      "__type__": "HeaderTagSlot"
+    },
+    "ref": "googletag.Slot",      // reference to the slot on the page, in this example it is a googletag slot
+    "xSlotRef": {   // contains the reference to the xSlot object from the partner configuration.
+      "placementID": "123",
+      "sizes": [ [300, 250], [300, 600] ]
+    },
+    "xSlotName": "1",
+    "requestId": "_fwyvecpA" // generated by the wrapper is used to map the creative back to a piece of demand.
+                            // This will show up as targeting under the id key, and is used by the render function.
+}
+```
+
+These parcels will be fed into both of the functions that your adapter needs to implement:
+
+1. First `generateRequestObj` will need to craft a bid request for the `parcels` that need demand.
+
+2. Second `parseResponse` will take the same parcels and apply the demand (set specific properties in the parcel objects) that is returned from the bid requests to the same parcels and send them back to the wrapper.
+
+## <a name='eventModel'></a> High Level Event Model
+
+1. The Header Tag Wrapper script tag is loaded on the page.
+2. Wrapper specific configuration validation is performed.
+3. All the partner modules are instantiated.
+    * Partner-specific configuration validation is performed - checking that all the required fields are provided and that they are in the correct format.
+4. An external request for demand is made to the wrapper. This can be via a googletag display or refresh call, or by other methods depending on the wrapper product in use.
+The wrapper requests demand from the partner modules for the required slots (provided in the form of parcels).
+    * The wrapper calls `generateRequestObj(returnParcels)` for every partner module.
+    * The adapter then crafts and returns a request object based on the parcels (containing slot information) specified.
+    * The wrapper then sends out a bid request using the request object.
+    * Depending on how the adapter is set up and whether JSONP is supported, a response callback (`adResponseCallback`) is called.
+    * The adapter parses the response (`parseResponse`) and attaches the demand to the same returnParcels. It also registers the ad creative with the wrapper's render service.
+    * The returnParcels are then sent back to the wrapper.
+5. The wrapper applies targeting using the demand from the returnParcels.
+6. If the partner wins the auction in the ad server, their creative code will be returned and executed.
+    * The creative code contains a call to the wrapper's render function.
+7. The partner ad is rendered.
+
+## <a name='creatingPartnerModule'></a> Creating a Partner Module
+
+In this section you will be filling out the rubicon-htb.js, rubicon-htb-exports.js, and the rubicon-htb-validator.js files to create your module.
+
+### Step 0: Config Validation (`rubicon-htb-validator.js`)
+Before you get started on writing the actual code for your module, you need to figure out what your partner configuration (refer to [Configuration](#configuration)) object will look like. This is crucial because it will determine the input (parcels) to your module's core functions.
+
+Once you have a basic idea of what this will look like, and how you will uniquely identify each slot on your server (via xSlot placementId or other inventory codes) you will need to validate this configuration. This validation will be performed by the wrapper using the `rubicon-htb-validator.js` file.
+
+The `rubicon-htb-validator.js` file contains a single export, a `partnerValidator` function, that takes in the configuration object that will be fed to your module's constructor (refer to [Configuration](#configuration) for an example layout) and validates it via type checks. The type checks are performed using an external library called `schema-inspector`, for which the documentation can be found here https://github.com/Atinux/schema-inspector.
+
+Once you have filled this file out, you can continue actually writing your module!
+
+### Step 1: Partner Configuration (`rubicon-htb.js`)
+This section involves setting up the general partner configuration such as name, default pricing strategy as well as the general format of incoming/outgoing bids for the adapter. Please read the following descriptions and update the `__profile` variable if necessary.
+
+* <u>partnerId</u> - This is simply the name of our module, generally if your module is a bidder the name will end with Htb. The format of the name should be PartnerName{Type}.
+* <u>namespace</u> - Should be the same as partnerId, it is the namespace that is used internally to store all of variables/functions related to your module, i.e. adResponseCallbacks.
+* <u>statsId</u> - A unique identifier used for analytics that will be provided for you.
+* <u>version</u> - If this is the first iteration of your module, please leave this field at 2.0.0.
+* <u>targetingType</u> - The targeting type of your bidder, the default is slot for slot level targeting but could also be page.
+* <u>enabledAnalytics</u> - The analytics that the wrapper will track for the module. requestTime is the only currently supported analytic, which records different times around when bid requests occur.
+* <u>features</u> - Extra features that a partner can support
+    * <u>demandExpiry</u> - Setting an expiry time on the demand that partner returns.
+    * <u>rateLimiting</u> - Used for limiting the amount of requests to a given partner for a given slot on pages that support rate limiting in DFP.
+* <u>targetingKeys</u> - Different targeting keys that will be used to record demand for a given parcel.
+    * <u>id</u> - This key will be used to trace back the creative that has won in DFP for rendering.
+    * <u>om</u> - This key signals the open market bid in CPM.
+    * <u>pm</u> - This key signals the private market bid in CPM.
+    * <u>pmid</u> - This key signals the private market deal id.
+* <u>bidUnitInCents</u> - This tells the wrapper the unit of the bid price returned by your endpoint. The unit is in terms of cents, thus it should be set to 100 if your endpoint returns dollars, 1 if your endpoint returns cents, 0.1 if your endpoint returns tenth of a cent, etc. Note that this value must be an integer power of 10.
+
+The last three properties are critical for the wrapper to understand how to interact with the endpoint:
+* callbackType:
+    * <u>Partner.CallbackTypes.ID</u> -
+        Use this option if your endpoint accepts an arbitrary identifier in requests which will be returned in the matching response. You will need to set this callbackId in the `generateRequestObj` function and retrieve it in the adResponseCallback function. This is the preferred method for matching requests and responses. Pass the following reference into your request object when generating the request object in `generateRequestObj`.
+        `SpaceCamp.NAMESPACE + '.' + __profile.namespace + '.adResponseCallback'`. You will need to fill out the `adResponseCallback` function to store the ad response in the `__baseClass._adResponseStore[callbackId]` object, where `callbackId` is the same callbackId that was passed back to the wrapper as part of the object that is returned in `generateRequestObj`. The wrapper will use the `callbackId` to reference to pull your stored ad response from that `adResponseStore` and feed it back to `parseResponse`. You will also need to expose this function inside your exports file, see below exports section for more information.
+    * <u>Partner.CallbackTypes.CALLBACK_NAME</u> -
+        Use this option if your endpoint has no parameter which can be used as a callback ID. The wrapper will generate a new callback function for each request, and use the function name to tie requests to responses. Similarly to the above ID method, you can reference the generated ad response callback as such: `'window.' + SpaceCamp.NAMESPACE + '.' + __profile.namespace + '.adResponseCallbacks.' + callbackId`, where `callbackId` is the same unique callbackId that is passed back to the wrapper as part of the object that is returned in `generateRequestObj`. Unlike the ID method above, you do not need to fill out the `adResponseCallback` function. The response will simply be passed into the `parseResponse` function.
+    * <u>Partner.CallbackTypes.NONE</u> -
+        Use this option if your endpoint supports AJAX only and will return a pure JSON response rather than JSONP with a callback function. In this mode your endpoint will not receive any demand requests if the user is using a browser which does not fully support AJAX, such as Internet Explorer 9 or earlier. In this mode,
+        you also do NOT need to provide a callback function in `generateRequestObj`.
+* architecture:
+    * <u>Partner.Architectures.MRA</u> -
+        Use this option (Multi-Request Architecture) if your endpoint requires a separate network request for each ad slot. In this mode your endpoint will receive one network request for every xSlot mapping active in the current wrapper demand request.
+    * <u>Partner.Architectures.FSRA</u> -
+        Use this option (Fully Single-Request Architecture) if your endpoint can handle any number of slots in a single request in any combination, including multiple requests for the same slot. In this mode your endpoint will receive a single network request per wrapper demand request.
+    * <u>Partner.Architectures.SRA</u> -
+        Use this option (Single-Request Architecture) if your endpoint can handle any number of slots in a single request, but cannot repeat the same xSlot more than once in a given request. e.g., you use a placementId and can receive a request for multiple placementIds at once, but not for the same placementId twice. The wrapper will arrange the mapped xSlots into the minimum possible number of network requests to your endpoint.
+* requestType:
+    * <u>Partner.RequestTypes.ANY</u> -
+        Use any request type when making requests. The wrapper will attempt to make an AJAX request for your bid requests, if XHR is not supported, the wrapper will attempt to make a JSONP request if possible.
+    * <u>Partner.RequestTypes.AJAX</u> -
+        Use only AJAX for bid requests. Note, if the browser does not support ajax the bid requests will not go out.
+    * <u>Partner.RequestTypes.JSONP</u> -
+        Use only JSONP for bid requests.
+
+### Step 2: Generate Request URL (`rubicon-htb.js`)
+This step is for crafting a bid request URL given a specific set of parcels.
+
+For this step, you must fill out the `generateRequestObj(returnParcels)` function. This function takes in an array of returnParcels.
+These are the parcel objects that contain the different slots for which demand needs to be requested.
+
+The wrapper will ensure that the array contains an appropriate set of parcels to pass into a single network
+request for your endpoint based on the value set in __profile.architecture. Note, in the particular case your
+architecture is MRA, this array will have length 1.
+
+Using this array of parcels, the adapter must craft a request object that will be used to send out the bid request for these slots. This object must contain the request URL, an object containing query parameters, and a callbackId.
+
+The final returned object should looks something like this:
+```javascript
+{
+    url: 'http://bidserver.com/api/bids' // base request URL for a GET request
+    data: { // query string object that will be attached to the base URL
+        slots: [
+            {
+                placementId: 54321,
+                sizes: [[300, 250]]
+            },{
+                placementId: 12345,
+                sizes: [[300, 600]]
+            },{
+                placementId: 654321,
+                sizes: [[728, 90]]
+            }
+        ],
+        site: 'http://google.com'
+    },
+    callbackId: '_23sd2ij4i1' //unique id used for pairing requests and responses
+}
+```
+
+If your endpoint uses POST please add the following `networkParamOverrides` object to your return object:
+```javascript
+{
+    url: 'http://bidserver.com/api/bids' // base request URL for a POST request
+    data: { // will be the payload in the POST request
+        slots: [
+            {
+                placementId: 54321,
+                sizes: [[300, 250]]
+            },{
+                placementId: 12345,
+                sizes: [[300, 600]]
+            },{
+                placementId: 654321,
+                sizes: [[728, 90]]
+            }
+        ],
+        site: 'http://google.com'
+    },
+    callbackId: '_23sd2ij4i1' //unique id used for pairing requests and responses,
+
+    /* Signals a POST request and the content type */
+    networkParamOverrides: {
+        method: 'POST',
+        contentType: 'text/plain'
+    }
+}
+```
+
+More information can be found in the comment section of the function itself.
+
+### Step 3: Response Callback (`rubicon-htb.js`)
+Once the request from Step 2 finishes the `adResponseCallback` will be called to store the returned response in a `adResponseStore` object.
+
+If `__profile.callbackType` is set to `CALLBACK_NAME` or `NONE`, the wrapper will handle the callback for you and you can remove this function. If it is set to ID, you must retrieve the callback ID from the network response and store that response in the `_adResponseStore` object keyed by the callback ID.
+
+See the function in the template for details.
+
+### Step 4: Parsing and Storing Demand (`rubicon-htb.js`)
+In this step the adapter must parse the returned demand from the bid response and attach it the returnParcels objects.
+The returnParcels array will be one of the same arrays that was passed to `generateRequestObj` earlier.
+
+This step involves first matching the returned bids to the internal returnParcels objects. This can be done via some
+identifier that was setup for an xSlot (for example, a placementId) in the partner configuration and the same id being present in the bid response object.
+
+This function first iterates over all of the returned bids, parsing them and attaching the demand to the returnParcel objects (which will be implicitly passed back to the wrapper). This step also involves registering the creative (if returned) with the render service, which is responsible for storing and rendering that creative if the corresponding demand wins the DFP auction.
+
+In order to complete this step correctly, please fill out the section which includes the matching criteria. This step is necessary to map returnParcel objects to the returned bids correctly. In order to do this, we need to use some common criteria that is present both in the xSlot configuration and in the returned bids (usually placementIds or inventory codes).
+
+Also please fill out each of the variables for each bid, these will be attached to the parcel objects to store the demand:
+
+* bidPrice - The bid price for the given slot
+* bidWidth - The width of the given slot
+* bidHeight - The height of the given slot
+* bidCreative - The creative/adm for the given slot that will be rendered if is the winner. Needs to be decoded and ready for a doc.write.
+* bidDealId - The dealId if applicable for this slot.
+* bidIsPass - True/false value for if the module returned a pass for this slot.
+* pixelUrl - If you require firing a tracking pixel after your creative wins and your tracking pixel is not part of the original adm that is rendered, please provide the decoded URL of the tracking pixel here. This `pixelUrl` variable will then be passed to the `__renderPixel` function, which will then be called by either your module's specific `render` function or a generic rendering function depending on the line item setup.
+
+After filling out these objects, the resulting returnParcel objects should look something like this:
+
+```javascript
+{
+    "partnerId": "RUBI",
+    "htSlot": {
+      "__type__": "HeaderTagSlot"
+    },
+    "ref": "googletag.Slot",      // reference to the slot on the page, in this example it is a googletag slot
+    "xSlotRef": {   // contains the reference to the xSlot object from the partner configuration.
+      "placementID": "123",
+      "sizes": [ [300, 250], [300, 600] ]
+    },
+    "xSlotName": "1",
+    "requestId": "_fwyvecpA",
+
+    // notice these new fields with demand
+    "targetingType": "slot"
+    "targeting" : {
+        "ix_rubi_id": ["_230l09jd2"],
+        "ix_rubi_cpm": ["300x250_2.50"]
+    },
+    "price": 2.50,
+    "size": [300,250],
+    "adm": "<script> test creative </script>"
+}
+```
+
+### Step 5: Rendering Pixel (`rubicon-htb.js`)
+This step is only required if your adapter needs to fire a tracking pixel after your creative renders. The function `__renderPixel` will be called right after we render your winning creative.
+It will be called with the parameter `pixelUrl` that needs to be filled out in `__parseResponse`.
+
+### Step 6: Exports (`rubicon-htb-exports.js`)
+In this step, you will be required to fill out the exports file for your module. This file will contain all of the functions that will need to be exposed to outside page if they need to be accessed outside of the wrapper. In the usual case, all you will need to change in this file is your partner module's name in the included snippet:
+
+```javascript
+shellInterface.RubiconHtb = { //shell interface is the window variable that is accessible through the window object, currently this will always be window.headertag
+    render: SpaceCamp.services.RenderService.renderDfpAd.bind(null, 'RubiconHtb')
+};
+```
+
+This snippet, exposes your module's render function to the outside world via the `window.headertag` namespace.
+
+If your module requires using a custom adResponse callback via Partner.CallbackTypes.ID callback type, that callback will need to be exposed here. Which would look something like this:
+
+```javascript
+if (__directInterface.Layers.PartnersLayer.Partners.RubiconHtb) {
+    shellInterface.RubiconHtb = shellInterface.RubiconHtb || {};
+    shellInterface.RubiconHtb.adResponseCallback = __directInterface.Layers.PartnersLayer.Partners.RubiconHtb.adResponseCallback;
+}
+```
+
+If your module requires using a custom adResponse callback via Partner.CallbackTypes.NAME callback type, that callback swill need to be exposed here. Which would look something like this:
+
+```javascript
+if (__directInterface.Layers.PartnersLayer.Partners.RubiconHtb) {
+    shellInterface.RubiconHtb = shellInterface.RubiconHtb || {};
+    shellInterface.RubiconHtb.adResponseCallbacks = __directInterface.Layers.PartnersLayer.Partners.RubiconHtb.adResponseCallbacks;
+}
+```
+
+# <a name='helpers'></a> Utility Libraries
+There are a lot of helper objects available to you in you partner module.
+
+### Utilities
+* `isObject(entity)` - Return true if entity is an object.
+* `isArray(obj)` - Return true if obj is an array.
+* `isNumber(entity)` - Return true if entity is a number.
+* `isString(entity)` - Return true if entity is a string.
+* `isBoolean(entity)` - Return true if entity is a boolean.
+* `isFunction(entity)` - Return true if entity is a function.
+* `isRegex(entity)` - Return true if entity is a regex.
+* `isEmpty(entity)`
+    * if entity is a string, return true if string is empty.
+    * if entity is an object, return true if the object has no properties.
+    * if entity is an array, return true if the array is empty.
+* `arrayDelete(arr, value)` - Delete given value from an object or array.
+* `randomSplice(arr)` - Returns a randomly spliced item from an array.
+* `deepCopy(entity)` - Return a deep copy of the entity.
+* `mergeObjects(entity1, entity2, ...)` - Takes the first entity and overwrites it with the next entity, returning the final object.
+* `mergeArrays(arr1, arr2, ...)` - Merge all of the specified arrays into one and return it.
+* `tryCatchWrapper(fn, args, errorMessage, context)` - Wrap the given arguments into a try catch block. Returning a function.
+* `isArraySubset(arr1, arr2, matcher)` - Return true if `arr1` is a subset of `arr2`.
+
+### System
+* `now()` - Return the number of milliseconds since 1970/01/01.
+* `generateUniqueId(len, charSet)` - Creates a unique identifier of the given length using the optionally specified charset:
+    * `ALPHANUM`: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789',
+    * `ALPHA`: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
+    * `ALPHA_UPPER`: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+    * `ALPHA_LOWER`: 'abcdefghijklmnopqrstuvwxyz',
+    * `NUM`: '0123456789'
+* `getTimezoneOffset()` - Returns the timezone offset.
+* `documentWrite(doc, data)` - doc.write the data using the specified document `doc`.
+
+### Size
+* `arrayToString(arr)` - Returns the string representation of an array in the form of '300x250'.
+* `stringToArray(str)` - Return the array rep representation of a string in the form of [300, 250].
+
+### Browser
+* `getProtocol(httpValue, httpsValue)` - Return `document.location.protocol` or `httpValue` if `document.location.protocol` is http and `httpsValue` if `document.location.protocol` is https.
+* `isLocalStorageSupported()` - Checks if local storage is supported.
+* `getViewportWidth()` - Return viewport width.
+* `getViewportHeight()` - Return viewport height.
+* `isTopFrame()` - Checks to see if the code is being run in the top frame or iframe.
+* `getScreenWidth()` - Returns screen.width.
+* `getScreenHeight()` - Returns screen.height.
+* `getReferrer()` - Return document.referrer.
+* `getPageUrl()` - Return the page's URL.
+* `getHostname()` - Return the page's hostname.
+* `getNearestEntity(entityName)` - Returns the entity with `entityName` in the nearest `window` scope.
+* `createHiddenIFrame(srcUrl, scope)` - Generate a hidden iframe and then append it to the body. Use the `srcUrl` and `scope` if provided.
+
+### <a name='deviceTypeChecker'></a> DeviceTypeChecker
+* `getDeviceType()` - Returns the device type.
+
+### <a name='bidRounding'></a> BidRoundingTransformer
+* `apply(rawBid)` - Transform rawBid into the configured format. This includes, rounding/flooring according to the configuration that was used to instantiate the library. The bidTransformConfig is an object of the format:
+    * `floor` - Minimum acceptable bid price.
+    * `inputCentsMultiplier` - Multiply input bids by this to get cents. This is identical to bidUnitInCents in `__profile`.
+    * `outputCentsDivisor` -  Divide output bids in cents by this.
+    * `outputPrecision` - Decimal places in output.
+    * `roundingType` - Should always be 1.
+    * `buckets` - Buckets specifying rounding steps.
+
+Note that bid transformer instances suitable for DFP targeting and price reporting are already provided via `__baseClass._bidTransformers`. It is recommended to use the provided instances as they are sufficient for almost all use cases.
+
+# <a name='linting'></a> Linting
+All code must pass the linting before it is submitted for review. Follow the instructions [here](https://knowledgebase.indexexchange.com/display/ADAPTER/ESLint) to run the linter.
+
+# <a name='debugging'></a> Debugging
+To walk through your bidder code and debug, follow the instructions [here](https://knowledgebase.indexexchange.com/display/ADAPTER/Adapter+Debugger).
+
+# <a name='testing'></a> Testing
+To implement the system tests, follow the instructions [here](https://knowledgebase.indexexchange.com/display/ADAPTER/Test+Cases).
+
+# <a name='codeSubmissionGuidelines'></a> Code Submission Guidelines
+Follow the steps [here](https://knowledgebase.indexexchange.com/display/ADAPTER/Adapter+Code+Submission+Guidelines) to submit your code for review to Index Exchange.

--- a/rubicon/rubicon-htb-exports.js
+++ b/rubicon/rubicon-htb-exports.js
@@ -1,0 +1,10 @@
+//? if(FEATURES.GPT_LINE_ITEMS) {
+shellInterface.RubiconHtb = {
+    render: SpaceCamp.services.RenderService.renderDfpAd.bind(null, 'RubiconHtb')
+};
+
+//?     if (FEATURES.RUBICON_LINE_ITEMS) {
+window.top.rubicontag = window.top.rubicontag || {};
+window.top.rubicontag.renderCreative = SpaceCamp.services.RenderService.renderRubiconAd.bind(null, 'RubiconHtb');
+//?     }
+//? }

--- a/rubicon/rubicon-htb-system-tests.js
+++ b/rubicon/rubicon-htb-system-tests.js
@@ -1,0 +1,193 @@
+'use strict';
+
+function getPartnerId() {
+    return 'RubiconHtb';
+}
+
+function getBidRequestRegex() {
+    return {
+        method: 'GET',
+        urlRegex: /.*fastlane\.rubiconproject\.com\/a\/api\/fastlane.json.*/
+    };
+}
+
+function getCallbackType() {
+    return 'NONE';
+}
+
+function getArchitecture() {
+    return 'MRA';
+}
+
+function getStatsId() {
+    return 'RUBI';
+}
+
+function validateBidRequest(request) {
+    var r = request.query;
+
+    expect(r.account_id).toBe('1234');
+
+    expect(r.site_id).toBe('112233');
+
+    expect(r.zone_id).toBe('556677');
+
+    expect(r.size_id).toBe('15');
+
+    expect(r.alt_size_ids).toBe('10');
+
+    expect(r.rf).toEqual(jasmine.anything());
+}
+
+function validateBidRequestWithPrivacy(request) {
+    var r = request.query;
+
+    expect(r.gdpr).toBe('1');
+
+    expect(r.gdpr_consent).toBe('TEST_GDPR_CONSENT_STRING');
+}
+
+function getConfig() {
+    return {
+        accountId: '1234',
+        xSlots: {
+            1: {
+                siteId: '112233',
+                zoneId: '556677',
+                sizes: [[300, 250], [300, 600]]
+            }
+        }
+    };
+}
+
+function getValidResponse(request, creative) {
+    var adm = '</script>' + creative + '<script>';
+    var response = {
+        status: 'ok',
+        account_id: 1234,
+        site_id: 112233,
+        zone_id: 556677,
+        size_id: 15,
+        tracking: '',
+        inventory: {
+        },
+        ads: [
+            {
+                status: 'ok',
+                impression_id: '1234test-1234-12q1-12e4-c08098test',
+                size_id: '15',
+                ad_id: '6789',
+                advertiser: 5678,
+                network: 1902,
+                creative_id: '1902:12345',
+                type: 'script',
+                script: adm,
+                campaign_id: 48985,
+                rtb_rule_id: 1598010,
+                cpm: 2,
+                targeting: [
+                    {
+                        key: 'rpfl_1234',
+                        values: ['15_tier00015']
+                    }
+                ]
+            }
+        ]
+    };
+
+    return JSON.stringify(response);
+}
+
+function validateTargeting(targetingMap) {
+    expect(targetingMap).toEqual(jasmine.objectContaining({
+        ix_rubi_om: jasmine.arrayContaining(['300x250_200']),
+        ix_rubi_id: jasmine.arrayContaining([jasmine.any(String)])
+    }));
+}
+
+function getPassResponse() {
+    var skipResponse = {
+        status: 'ok',
+        account_id: 1234,
+        site_id: 112233,
+        zone_id: 556677,
+        size_id: 15,
+        alt_size_ids: [10],
+        tracking: '',
+        inventory: {
+        },
+        ads: [
+            {
+                status: 'no-ads',
+                reason: 'floor-not-met',
+                error_code: '10',
+                impression_id: '1234test-1234-12q1-12e4-c08098test'
+            }
+        ]
+    };
+
+    return JSON.stringify(skipResponse);
+}
+
+function getValidResponseWithDeal(request, creative) {
+    var adm = '</script>' + creative + '<script>';
+    var response = {
+        status: 'ok',
+        account_id: 1234,
+        site_id: 112233,
+        zone_id: 556677,
+        size_id: 15,
+        tracking: '',
+        inventory: {
+        },
+        ads: [
+            {
+                status: 'ok',
+                impression_id: '1234test-1234-12q1-12e4-c08098test',
+                size_id: '15',
+                ad_id: '6789',
+                advertiser: 5678,
+                network: 1902,
+                creative_id: '1902:12345',
+                type: 'script',
+                script: adm,
+                campaign_id: 48985,
+                rtb_rule_id: 1598010,
+                cpm: 2,
+                deal: 12345,
+                targeting: [
+                    {
+                        key: 'rpfl_1234',
+                        values: ['deal_tierAll']
+                    }
+                ]
+            }
+        ]
+    };
+
+    return JSON.stringify(response);
+}
+
+function validateTargetingWithDeal(targetingMap) {
+    expect(targetingMap).toEqual(jasmine.objectContaining({
+        ix_rubi_om: jasmine.arrayContaining(['300x250_200']),
+        ix_rubi_id: jasmine.arrayContaining([jasmine.any(String)]),
+        rpfl_1234: jasmine.arrayContaining(['deal_tierAll'])
+    }));
+}
+
+module.exports = {
+    getPartnerId: getPartnerId,
+    getBidRequestRegex: getBidRequestRegex,
+    getCallbackType: getCallbackType,
+    getConfig: getConfig,
+    getArchitecture: getArchitecture,
+    getStatsId: getStatsId,
+    validateBidRequest: validateBidRequest,
+    validateBidRequestWithPrivacy: validateBidRequestWithPrivacy,
+    getValidResponse: getValidResponse,
+    validateTargeting: validateTargeting,
+    getPassResponse: getPassResponse,
+    getValidResponseWithDeal: getValidResponseWithDeal,
+    validateTargetingWithDeal: validateTargetingWithDeal
+};

--- a/rubicon/rubicon-htb-validator.js
+++ b/rubicon/rubicon-htb-validator.js
@@ -1,0 +1,331 @@
+/**
+ * @author:    Partner
+ * @license:   UNLICENSED
+ *
+ * @copyright: Copyright (c) 2017 by Index Exchange. All rights reserved.
+ *
+ * The information contained within this document is confidential, copyrighted
+ * and or a trade secret. No part of this document may be reproduced or
+ * distributed in any form or by any means, in whole or in part, without the
+ * prior written permission of Index Exchange.
+ */
+
+'use strict';
+
+////////////////////////////////////////////////////////////////////////////////
+// Dependencies ////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+var Inspector = require('../../../libs/external/schema-inspector.js');
+
+////////////////////////////////////////////////////////////////////////////////
+// Main ////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+function partnerValidator(configs) {
+    var result = Inspector.validate({
+        type: 'object',
+        properties: {
+            accountId: {
+                type: 'string',
+                minLength: 1
+            },
+            xSlots: {
+                type: 'object',
+                properties: {
+                    '*': {
+                        type: 'object',
+                        properties: {
+                            siteId: {
+                                type: 'string',
+                                minLength: 1
+                            },
+                            zoneId: {
+                                type: 'string',
+                                minLength: 1
+                            },
+                            sizes: {
+                                type: 'array',
+                                minLength: 1,
+                                items: {
+                                    type: 'array',
+                                    exactLength: 2,
+                                    items: {
+                                        type: 'integer'
+                                    }
+                                }
+                            },
+                            slotFpd: {
+                                optional: true,
+                                type: 'object',
+                                strict: true,
+                                properties: {
+                                    inventory: {
+                                        optional: true,
+                                        type: 'object',
+                                        strict: true,
+                                        properties: {
+                                            vars: {
+                                                optional: true,
+                                                type: 'object',
+                                                properties: {
+                                                    '*': {
+                                                        type: 'array',
+                                                        items: {
+                                                            type: 'string',
+                                                            minLength: 1
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            strs: {
+                                                optional: true,
+                                                type: 'object',
+                                                properties: {
+                                                    '*': {
+                                                        type: 'array',
+                                                        items: {
+                                                            type: 'string',
+                                                            minLength: 1
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            fns: {
+                                                optional: true,
+                                                type: 'object',
+                                                properties: {
+                                                    '*': {
+                                                        type: 'object',
+                                                        strict: true,
+                                                        properties: {
+                                                            fn: {
+                                                                type: 'string',
+                                                                minLength: 1
+                                                            },
+                                                            args: {
+                                                                type: 'array',
+                                                                items: {
+                                                                    type: 'string',
+                                                                    minLength: 1
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    visitor: {
+                                        optional: true,
+                                        type: 'object',
+                                        strict: true,
+                                        properties: {
+                                            vars: {
+                                                optional: true,
+                                                type: 'object',
+                                                properties: {
+                                                    '*': {
+                                                        type: 'array',
+                                                        items: {
+                                                            type: 'string',
+                                                            minLength: 1
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            strs: {
+                                                optional: true,
+                                                type: 'object',
+                                                properties: {
+                                                    '*': {
+                                                        type: 'array',
+                                                        items: {
+                                                            type: 'string',
+                                                            minLength: 1
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            fns: {
+                                                optional: true,
+                                                type: 'object',
+                                                properties: {
+                                                    '*': {
+                                                        type: 'object',
+                                                        strict: true,
+                                                        properties: {
+                                                            fn: {
+                                                                type: 'string',
+                                                                minLength: 1
+                                                            },
+                                                            args: {
+                                                                type: 'array',
+                                                                items: {
+                                                                    type: 'string',
+                                                                    minLength: 1
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    position: {
+                                        optional: true,
+                                        type: 'string',
+                                        eq: ['atf', 'btf']
+                                    },
+                                    keywords: {
+                                        optional: true,
+                                        type: 'array',
+                                        items: {
+                                            type: 'string',
+                                            minLength: 1
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            partnerFpd: {
+                optional: true,
+                strict: true,
+                type: 'object',
+                properties: {
+                    inventory: {
+                        optional: true,
+                        type: 'object',
+                        strict: true,
+                        properties: {
+                            vars: {
+                                optional: true,
+                                type: 'object',
+                                properties: {
+                                    '*': {
+                                        type: 'array',
+                                        items: {
+                                            type: 'string',
+                                            minLength: 1
+                                        }
+                                    }
+                                }
+                            },
+                            strs: {
+                                optional: true,
+                                type: 'object',
+                                properties: {
+                                    '*': {
+                                        type: 'array',
+                                        items: {
+                                            type: 'string',
+                                            minLength: 1
+                                        }
+                                    }
+                                }
+                            },
+                            fns: {
+                                optional: true,
+                                type: 'object',
+                                properties: {
+                                    '*': {
+                                        type: 'object',
+                                        strict: true,
+                                        properties: {
+                                            fn: {
+                                                type: 'string',
+                                                minLength: 1
+                                            },
+                                            args: {
+                                                type: 'array',
+                                                items: {
+                                                    type: 'string',
+                                                    minLength: 1
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    keywords: {
+                        optional: true,
+                        type: 'array',
+                        items: {
+                            type: 'string',
+                            minLength: 1
+                        }
+                    },
+                    visitor: {
+                        optional: true,
+                        type: 'object',
+                        strict: true,
+                        properties: {
+                            vars: {
+                                optional: true,
+                                type: 'object',
+                                properties: {
+                                    '*': {
+                                        type: 'array',
+                                        items: {
+                                            type: 'string',
+                                            minLength: 1
+                                        }
+                                    }
+                                }
+                            },
+                            strs: {
+                                optional: true,
+                                type: 'object',
+                                properties: {
+                                    '*': {
+                                        type: 'array',
+                                        items: {
+                                            type: 'string',
+                                            minLength: 1
+                                        }
+                                    }
+                                }
+                            },
+                            fns: {
+                                optional: true,
+                                type: 'object',
+                                properties: {
+                                    '*': {
+                                        type: 'object',
+                                        strict: true,
+                                        properties: {
+                                            fn: {
+                                                type: 'string',
+                                                minLength: 1
+                                            },
+                                            args: {
+                                                type: 'array',
+                                                items: {
+                                                    type: 'string',
+                                                    minLength: 1
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }, configs);
+
+    if (!result.valid) {
+        return result.format();
+    }
+
+    return null;
+}
+
+module.exports = partnerValidator;

--- a/rubicon/rubicon-htb.js
+++ b/rubicon/rubicon-htb.js
@@ -1,0 +1,881 @@
+/**
+ * @author:    Partner
+ * @license:   UNLICENSED
+ *
+ * @copyright: Copyright (c) 2016 by Index Exchange. All rights reserved.
+ *
+ * The information contained within this document is confidential, copyrighted
+ * and or a trade secret. No part of this document may be reproduced or
+ * distributed in any form or by any means, in whole or in part, without the
+ * prior written permission of Index Exchange.
+ */
+
+'use strict';
+
+////////////////////////////////////////////////////////////////////////////////
+// Dependencies ////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+var Browser = require('browser.js');
+var Classify = require('classify.js');
+var Constants = require('constants.js');
+var Network = require('network.js');
+var Partner = require('partner.js');
+var Size = require('size.js');
+var SpaceCamp = require('space-camp.js');
+var System = require('system.js');
+var Utilities = require('utilities.js');
+var Whoopsie = require('whoopsie.js');
+
+var EventsService;
+var RenderService;
+var ComplianceService;
+
+//? if (DEBUG) {
+var ConfigValidators = require('config-validators.js');
+var Inspector = require('schema-inspector.js');
+var PartnerSpecificValidator = require('rubicon-htb-validator.js');
+var Scribe = require('scribe.js');
+//? }
+
+////////////////////////////////////////////////////////////////////////////////
+// Main ////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Partner module template
+ *
+ * @class
+ */
+
+function RubiconModule(configs) {
+    /* Rubicon endpoint only works with AJAX */
+    if (!Network.isXhrSupported()) {
+        //? if (DEBUG) {
+        Scribe.warn('Partner RubiconHtb requires AJAX support. Aborting instantiation.');
+        //? }
+
+        return null;
+    }
+
+    /* =====================================
+     * Data
+     * ---------------------------------- */
+
+    /* Private
+     * ---------------------------------- */
+
+    /**
+     * Reference to the partner base class.
+     *
+     * @private {object}
+     */
+    var __baseClass;
+
+    /**
+     * Profile for this partner.
+     *
+     * @private {object}
+     */
+    var __profile;
+
+    /**
+     * Base URL for the bidding end-point.
+     *
+     * @private {object}
+     */
+    var __baseUrl;
+
+    /**
+     * Mapping of sizes to rubicon size IDs
+     *
+     * @private {object}
+     */
+    var __sizeToSizeIdMapping;
+
+    var __pageFirstPartyData;
+
+    /* =====================================
+     * Functions
+     * ---------------------------------- */
+
+    /* Utilities
+     * ---------------------------------- */
+
+    /**
+     * Translates an array of size arrays to an array of Rubicon size IDs
+     * @param  {array} sizes [description]
+     * @return {array}       [description]
+     */
+    function __mapSizesToRubiconSizeIds(sizes) {
+        var rubiSizeIds = [];
+
+        for (var i = 0; i < sizes.length; i++) {
+            var sizeKey = Size.arrayToString(sizes[i]);
+            if (__sizeToSizeIdMapping.hasOwnProperty(sizeKey)) {
+                rubiSizeIds.push(__sizeToSizeIdMapping[sizeKey]);
+            } else {
+                //? if(DEBUG) {
+                Scribe.warn('No rubicon size id for size ' + sizeKey);
+                //? }
+            }
+        }
+
+        return rubiSizeIds;
+    }
+
+    /**
+     * Gets the actual size represented by a rubicon size id
+     *
+     * @param  {string} rubiconSize [description]
+     * @return {[type]}             [description]
+     */
+    function __mapRubiconSizeIdToSize(rubiconSize) {
+        for (var sizeKey in __sizeToSizeIdMapping) {
+            if (!__sizeToSizeIdMapping.hasOwnProperty(sizeKey)) {
+                continue;
+            }
+
+            if (__sizeToSizeIdMapping[sizeKey] === Number(rubiconSize)) {
+                return Size.stringToArray(sizeKey)[0];
+            }
+        }
+        //? if(DEBUG) {
+        Scribe.warn('Unknown rubicon size id ' + rubiconSize);
+        //? }
+
+        return [];
+    }
+
+    function __evalVariable(variableString) {
+        try {
+            /* eslint-disable no-eval */
+            return eval.call(null, variableString);
+            /* eslint-enable no-eval */
+        } catch (ex) {
+            //? if (DEBUG) {
+            Scribe.error('Error evaluating variable ' + variableString + ': ' + ex);
+            //? }
+        }
+
+        return null;
+    }
+
+    function __evalFunction(functionString, args) {
+        try {
+            /* eslint-disable no-eval */
+            return eval.call(null, functionString + '(' + args.join() + ')');
+            /* eslint-enable no-eval */
+        } catch (ex) {
+            //? if (DEBUG) {
+            Scribe.error('Error evaluating function ' + functionString + ': ' + ex);
+            //? }
+        }
+
+        return null;
+    }
+
+    function __transformFpdSubobject(subobject) {
+        var returnSubobject = {};
+
+        if (subobject.vars) {
+            var vars = subobject.vars;
+
+            for (var varsKey in vars) {
+                if (!vars.hasOwnProperty(varsKey)) {
+                    continue;
+                }
+
+                returnSubobject[varsKey] = returnSubobject[varsKey] || [];
+
+                for (var i = 0; i < vars[varsKey].length; i++) {
+                    var evaledVariable = __evalVariable(vars[varsKey][i]);
+
+                    if (evaledVariable !== null && evaledVariable !== 'undefined') {
+                        returnSubobject[varsKey].push(evaledVariable);
+                    }
+                }
+            }
+        }
+
+        if (subobject.strs) {
+            var strs = subobject.strs;
+
+            for (var strsKey in strs) {
+                if (!strs.hasOwnProperty(strsKey)) {
+                    continue;
+                }
+
+                returnSubobject[strsKey] = returnSubobject[strsKey] || [];
+
+                for (var j = 0; j < strs[strsKey].length; j++) {
+                    returnSubobject[strsKey].push(strs[strsKey][j]);
+                }
+            }
+        }
+
+        if (subobject.fns) {
+            var fns = subobject.fns;
+
+            for (var fnsKey in fns) {
+                if (!fns.hasOwnProperty(fnsKey)) {
+                    continue;
+                }
+
+                returnSubobject[fnsKey] = returnSubobject[fnsKey] || [];
+
+                var evaledValue = __evalFunction(fns[fnsKey].fn, fns[fnsKey].args);
+
+                if (evaledValue !== null && evaledValue !== 'undefined') {
+                    if (Utilities.isArray(evaledValue)) {
+                        for (var k = 0; k < evaledValue.length; k++) {
+                            returnSubobject[fnsKey].push(evaledValue[k]);
+                        }
+                    } else {
+                        returnSubobject[fnsKey].push(evaledValue);
+                    }
+                }
+            }
+        }
+
+        return returnSubobject;
+    }
+
+    function __transformFirstPartyData(fpdObject) {
+        var firstPartyData = {};
+
+        if (fpdObject.inventory) {
+            firstPartyData.inventory = __transformFpdSubobject(fpdObject.inventory);
+        }
+
+        if (fpdObject.visitor) {
+            firstPartyData.visitor = __transformFpdSubobject(fpdObject.visitor);
+        }
+
+        if (fpdObject.position) {
+            firstPartyData.position = fpdObject.position;
+        }
+
+        if (fpdObject.keywords) {
+            if (Utilities.isString(fpdObject.keywords)) {
+                firstPartyData.keywords = [fpdObject.keywords];
+            } else {
+                firstPartyData.keywords = fpdObject.keywords;
+            }
+        }
+
+        return firstPartyData;
+    }
+
+    function _getDigiTrustQueryParams() {
+        function getDigiTrustId() {
+            var digiTrustUser;
+            var _window;
+
+            if (!Browser.isTopFrame()) {
+                try {
+                    _window = window.top;
+                } catch (e) {
+                    _window = Browser.topWindow;
+                }
+            } else {
+                _window = window;
+            }
+
+            try {
+                digiTrustUser = _window.DigiTrust.getUser({ member: 'T9QSFKPDN9' });
+            } catch (e) {}
+
+            return (digiTrustUser && digiTrustUser.success && digiTrustUser.identity) || null;
+        }
+        var digiTrustId = configs.digitrustId || getDigiTrustId();
+
+        // Verify there is an ID and this user has not opted out
+        if (!digiTrustId || (digiTrustId.privacy && digiTrustId.privacy.optout)) {
+            return {};
+        }
+        var _dt = {
+            id: digiTrustId.id,
+            keyv: digiTrustId.keyv,
+            pref: 0
+        };
+
+        return _dt;
+    }
+
+    /**
+     * Generates the request URL to the endpoint for the xSlots in the given
+     * returnParcels.
+     *
+     * @param  {object[]} returnParcels [description]
+     * @return {string}            [description]
+     */
+
+    function __generateRequestObj(returnParcels) {
+        //? if (DEBUG){
+        var results = Inspector.validate({
+            type: 'array',
+            exactLength: 1,
+            items: {
+                type: 'object',
+                properties: {
+                    htSlot: {
+                        type: 'object'
+                    },
+                    xSlotRef: {
+                        type: 'object'
+                    },
+                    xSlotName: {
+                        type: 'string',
+                        minLength: 1
+                    },
+                    firstPartyData: {
+                        optional: true,
+                        properties: {
+                            rubicon: {
+                                optional: true,
+                                type: 'object',
+                                strict: true,
+                                properties: {
+                                    keywords: {
+                                        optional: true,
+                                        type: 'array',
+                                        items: {
+                                            type: 'string'
+                                        }
+                                    },
+                                    inventory: {
+                                        optional: true,
+                                        properties: {
+                                            '*': {
+                                                type: 'array',
+                                                items: {
+                                                    type: 'string'
+                                                }
+                                            }
+                                        }
+                                    },
+                                    visitor: {
+                                        optional: true,
+                                        properties: {
+                                            '*': {
+                                                type: 'array',
+                                                items: {
+                                                    type: 'string'
+                                                }
+                                            }
+                                        }
+                                    },
+                                    position: {
+                                        optional: true,
+                                        type: 'string'
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }, returnParcels);
+        if (!results.valid) {
+            throw Whoopsie('INVALID_ARGUMENT', results.format());
+        }
+        //? }
+
+        var callbackId = System.generateUniqueId();
+        var parcel = returnParcels[0];
+        var slotFirstPartyData = {};
+        var pageFirstPartyData = {};
+
+        if (parcel.firstPartyData && parcel.firstPartyData.rubicon) {
+            slotFirstPartyData = parcel.firstPartyData.rubicon;
+        } else if (parcel.xSlotRef.slotFpd) {
+            slotFirstPartyData = __transformFirstPartyData(parcel.xSlotRef.slotFpd);
+        }
+
+        if (__pageFirstPartyData) {
+            pageFirstPartyData = __pageFirstPartyData;
+        } else if (configs.partnerFpd) {
+            pageFirstPartyData = __transformFirstPartyData(configs.partnerFpd);
+        }
+
+        var rubiSizeIds = __mapSizesToRubiconSizeIds(parcel.xSlotRef.sizes);
+        var referrer = Browser.getPageUrl();
+
+        var gdprConsent = ComplianceService.gdpr && ComplianceService.gdpr.getConsent();
+        var privacyEnabled = ComplianceService.isPrivacyEnabled();
+        /* eslint-disable camelcase */
+        var queryObj = {
+            account_id: configs.accountId,
+            size_id: rubiSizeIds[0],
+            p_pos: slotFirstPartyData.position ? slotFirstPartyData.position : 'btf',
+            rp_floor: 0.01,
+            rf: referrer ? referrer : '',
+            p_screen_res: Browser.getScreenWidth() + 'x' + Browser.getScreenHeight(),
+            site_id: parcel.xSlotRef.siteId,
+            zone_id: parcel.xSlotRef.zoneId,
+            kw: 'rp.fastlane',
+            tk_flint: 'index',
+            rand: Math.random(),
+            dt: _getDigiTrustQueryParams()
+        };
+        /* eslint-enable camelcase */
+        if (gdprConsent && privacyEnabled && typeof gdprConsent === 'object') {
+            if (typeof gdprConsent.applies === 'boolean') {
+                queryObj.gdpr = Number(gdprConsent.applies);
+            }
+            /* eslint-disable camelcase */
+            queryObj.gdpr_consent = gdprConsent.consentString;
+            /* eslint-enable camelcase */
+        }
+
+        for (var pageInv in pageFirstPartyData.inventory) {
+            if (!pageFirstPartyData.inventory.hasOwnProperty(pageInv)) {
+                continue;
+            }
+            queryObj['tg_i.' + pageInv] = pageFirstPartyData.inventory[pageInv].toString();
+        }
+
+        for (var slotInv in slotFirstPartyData.inventory) {
+            if (!slotFirstPartyData.inventory.hasOwnProperty(slotInv)) {
+                continue;
+            }
+
+            if (queryObj.hasOwnProperty('tg_i.' + slotInv)) {
+                queryObj['tg_i.' + slotInv] += ',' + slotFirstPartyData.inventory[slotInv].toString();
+            } else {
+                queryObj['tg_i.' + slotInv] = slotFirstPartyData.inventory[slotInv].toString();
+            }
+        }
+
+        for (var pageVis in pageFirstPartyData.visitor) {
+            if (!pageFirstPartyData.visitor.hasOwnProperty(pageVis)) {
+                continue;
+            }
+            queryObj['tg_v.' + pageVis] = pageFirstPartyData.visitor[pageVis].toString();
+        }
+
+        for (var slotVis in slotFirstPartyData.visitor) {
+            if (!slotFirstPartyData.visitor.hasOwnProperty(slotVis)) {
+                continue;
+            }
+
+            if (queryObj.hasOwnProperty('tg_v.' + slotVis)) {
+                queryObj['tg_v.' + slotVis] += ',' + slotFirstPartyData.visitor[slotVis].toString();
+            } else {
+                queryObj['tg_v.' + slotVis] = slotFirstPartyData.visitor[slotVis].toString();
+            }
+        }
+        var keywords = [];
+
+        if (pageFirstPartyData.keywords) {
+            keywords = keywords.concat(pageFirstPartyData.keywords);
+        }
+
+        if (slotFirstPartyData.keywords) {
+            keywords = keywords.concat(slotFirstPartyData.keywords);
+        }
+
+        if (keywords.length > 0) {
+            queryObj.kw += ',' + keywords.toString();
+        }
+
+        if (rubiSizeIds.length > 1) {
+            /* eslint-disable camelcase */
+            queryObj.alt_size_ids = rubiSizeIds.slice(1)
+                .join(',');
+            /* eslint-enable camelcase */
+        }
+
+        return {
+            url: __baseUrl,
+            data: queryObj,
+            callbackId: callbackId
+        };
+    }
+
+    /* Helpers
+     * ---------------------------------- */
+
+    /* Parses adResponse and ads any demand into outParcels */
+    function __parseResponse(sessionId, adResponse, returnParcels) {
+        //? if (DEBUG){
+        var results = Inspector.validate({
+            type: 'array',
+            exactLength: 1,
+            items: {
+                type: 'object',
+                properties: {
+                    htSlot: {
+                        type: 'object'
+                    },
+                    xSlotRef: {
+                        type: 'object'
+                    },
+                    xSlotName: {
+                        type: 'string',
+                        minLength: 1
+                    }
+                }
+            }
+        }, returnParcels);
+        if (!results.valid) {
+            throw Whoopsie('INVALID_ARGUMENT', results.format());
+        }
+        //? }
+
+        /* Prepare the info to send to header stats */
+        var headerStatsInfo = {
+            sessionId: sessionId,
+            statsId: __profile.statsId
+        };
+
+        var bidReceived = false;
+
+        var bids = adResponse.ads || [];
+
+        /* If no bids returned, mark the original parcel as pass */
+        if (!bids.length) {
+            returnParcels[0].pass = true;
+        }
+
+        for (var i = 0; i < bids.length; i++) {
+            var curReturnParcel;
+
+            /* A rubicon slot may have more than one size, so we might need to return more than
+               one parcel */
+            if (i === 0) {
+                curReturnParcel = returnParcels[0];
+
+                /* Fill out the other required headerstats info from the parcel */
+                headerStatsInfo.htSlotId = curReturnParcel.htSlot.getId();
+                headerStatsInfo.requestId = curReturnParcel.requestId;
+                headerStatsInfo.xSlotNames = [curReturnParcel.xSlotName];
+            } else {
+                curReturnParcel = {
+                    partnerId: returnParcels[0].partnerId,
+                    htSlot: returnParcels[0].htSlot,
+                    ref: returnParcels[0].ref,
+                    xSlotRef: returnParcels[0].xSlotRef,
+                    xSlotName: returnParcels[0].xSlotName,
+                    requestId: returnParcels[0].requestId
+                };
+
+                returnParcels.push(curReturnParcel);
+            }
+
+            var bidPrice = bids[i].cpm || 0;
+
+            if (bids[i].status !== 'ok' || !Utilities.isNumber(bidPrice) || bidPrice <= 0) {
+                //? if (DEBUG) {
+                Scribe.info(__profile.partnerId
+                    + ' returned no demand for { zoneId: '
+                    + curReturnParcel.xSlotRef.zoneId
+                    + ' }.');
+                //? }
+
+                curReturnParcel.pass = true;
+
+                continue;
+            }
+
+            bidReceived = true;
+
+            var bidDealId = bids[i].deal || '';
+            var bidSize = __mapRubiconSizeIdToSize(bids[i].size_id);
+            var bidCreative = '<html><head><scr'
+                + 'ipt type="text/javascript">inDapIF=true;</scr'
+                + 'ipt>'
+                + '</head><body style="margin : 0; padding: 0;"><!-- Rubicon Project Ad Tag -->'
+                + '<div data-rp-impression-id="'
+                + bids[i].impression_id
+                + '">'
+                + '<scr'
+                + 'ipt type="text/javascript">'
+                + bids[i].script
+                + '</scr'
+                + 'ipt></div></body></html>';
+
+            curReturnParcel.size = bidSize;
+            curReturnParcel.targetingType = 'slot';
+            curReturnParcel.targeting = {};
+
+            var targetingCpm = '';
+
+            //? if(FEATURES.GPT_LINE_ITEMS) {
+            targetingCpm = __baseClass._bidTransformers.targeting.apply(bidPrice);
+
+            if (__baseClass._configs.lineItemType === Constants.LineItemTypes.CUSTOM) {
+                if (bids[i].targeting) {
+                    var rubiTargeting = bids[i].targeting;
+
+                    for (var j = 0; j < rubiTargeting.length; j++) {
+                        curReturnParcel.targeting[rubiTargeting[j].key] = rubiTargeting[j].values;
+                    }
+                }
+                /* eslint-disable camelcase */
+                curReturnParcel.targeting.rpfl_elemid = [curReturnParcel.requestId];
+                /* eslint-enable camelcase */
+            } else {
+                var sizeKey = Size.arrayToString(curReturnParcel.size);
+
+                if (bidDealId) {
+                    curReturnParcel.targeting[__baseClass._configs.targetingKeys.pm] = [sizeKey + '_' + bidDealId];
+
+                    /* Set the custom KVPs for deal only so Rubicon handle tier deal line items */
+
+                    if (bids[i].targeting) {
+                        var rubiTargetingDeal = bids[i].targeting;
+                        for (var k = 0; k < rubiTargetingDeal.length; k++) {
+                            curReturnParcel.targeting[rubiTargetingDeal[k].key] = rubiTargetingDeal[k].values;
+                        }
+                    }
+                }
+
+                /* Set the om key as long as they sent _something_ in the cpm, even if it was zero */
+
+                if (bids[i].hasOwnProperty('cpm')) {
+                    curReturnParcel.targeting[__baseClass._configs.targetingKeys.om] = [sizeKey + '_' + targetingCpm];
+                }
+
+                curReturnParcel.targeting[__baseClass._configs.targetingKeys.id] = [curReturnParcel.requestId];
+            }
+            //? }
+
+            //? if(FEATURES.RETURN_CREATIVE) {
+            curReturnParcel.adm = bidCreative;
+            //? }
+
+            //? if(FEATURES.RETURN_PRICE) {
+            curReturnParcel.price = Number(__baseClass._bidTransformers.price.apply(bidPrice));
+            //? }
+
+            var pubKitAdId = RenderService.registerAd({
+                sessionId: sessionId,
+                partnerId: __profile.partnerId,
+                adm: bidCreative,
+                requestId: curReturnParcel.requestId,
+                size: curReturnParcel.size,
+                price: targetingCpm ? targetingCpm : '',
+                dealId: bidDealId ? bidDealId : '',
+                timeOfExpiry: __profile.features.demandExpiry.enabled ? __profile.features.demandExpiry.value + System.now() : 0 // eslint-disable-line
+            });
+
+            //? if(FEATURES.INTERNAL_RENDER) {
+            curReturnParcel.targeting.pubKitAdId = pubKitAdId;
+            //? }
+        }
+
+        if (__profile.enabledAnalytics.requestTime) {
+            var result = 'hs_slot_pass';
+
+            if (bidReceived) {
+                result = 'hs_slot_bid';
+            } else if (adResponse.status !== 'ok') {
+                result = 'hs_slot_error';
+            }
+
+            EventsService.emit(result, headerStatsInfo);
+        }
+    }
+
+    /**
+     * Set page-level first party data
+     *
+     * @param {object} data [description]
+     */
+    function setFirstPartyData(data) {
+        //? if (DEBUG){
+        var results = Inspector.validate({
+            type: 'object',
+            strict: true,
+            properties: {
+                keywords: {
+                    optional: true,
+                    type: 'array',
+                    items: {
+                        type: 'string'
+                    }
+                },
+                inventory: {
+                    optional: true,
+                    properties: {
+                        '*': {
+                            type: 'array',
+                            items: {
+                                type: 'string'
+                            }
+                        }
+                    }
+                },
+                visitor: {
+                    optional: true,
+                    properties: {
+                        '*': {
+                            type: 'array',
+                            items: {
+                                type: 'string'
+                            }
+                        }
+                    }
+                }
+            }
+        }, data);
+        if (!results.valid) {
+            throw Whoopsie('INVALID_ARGUMENT', results.format());
+        }
+        //? }
+
+        __pageFirstPartyData = data;
+    }
+
+    /* =====================================
+     * Constructors
+     * ---------------------------------- */
+
+    (function __constructor() {
+        EventsService = SpaceCamp.services.EventsService;
+        RenderService = SpaceCamp.services.RenderService;
+        ComplianceService = SpaceCamp.services.ComplianceService;
+
+        __profile = {
+            partnerId: 'RubiconHtb',
+            namespace: 'RubiconHtb',
+            statsId: 'RUBI',
+            version: '2.1.4',
+            targetingType: 'slot',
+            enabledAnalytics: {
+                requestTime: true
+            },
+            features: {
+                demandExpiry: {
+                    enabled: false,
+                    value: 0
+                },
+                rateLimiting: {
+                    enabled: false,
+                    value: 0
+                }
+            },
+            targetingKeys: {
+                id: 'ix_rubi_id',
+                om: 'ix_rubi_om',
+                pm: 'ix_rubi_pm'
+            },
+            bidUnitInCents: 100,
+            lineItemType: Constants.LineItemTypes.ID_AND_SIZE,
+            callbackType: Partner.CallbackTypes.NONE,
+            architecture: Partner.Architectures.MRA,
+            requestType: Partner.RequestTypes.AJAX
+        };
+
+        //? if (DEBUG) {
+        var results = ConfigValidators.partnerBaseConfig(configs) || PartnerSpecificValidator(configs);
+
+        if (results) {
+            throw Whoopsie('INVALID_CONFIG', results);
+        }
+        //? }
+
+        __sizeToSizeIdMapping = {
+            '468x60': 1,
+            '728x90': 2,
+            '120x600': 8,
+            '160x600': 9,
+            '300x600': 10,
+            '250x250': 14,
+            '300x250': 15,
+            '336x280': 16,
+            '300x100': 19,
+            '980x120': 31,
+            '250x360': 32,
+            '180x500': 33,
+            '980x150': 35,
+            '468x400': 37,
+            '930x180': 38,
+            '320x50': 43,
+            '300x50': 44,
+            '300x300': 48,
+            '300x1050': 54,
+            '970x90': 55,
+            '970x250': 57,
+            '1000x90': 58,
+            '320x80': 59,
+            '320x150': 60,
+            '1000x1000': 61,
+            '640x480': 65,
+            '320x480': 67,
+            '1800x1000': 68,
+            '320x320': 72,
+            '320x160': 73,
+            '980x240': 78,
+            '980x300': 79,
+            '980x400': 80,
+            '480x300': 83,
+            '970x310': 94,
+            '970x210': 96,
+            '480x320': 101,
+            '768x1024': 102,
+            '480x280': 103,
+            '320x240': 108,
+            '1000x300': 113,
+            '320x100': 117,
+            '800x250': 125,
+            '200x600': 126,
+            '320x250': 159,
+            '970x1000': 264,
+            '840x250': 158,
+            '840x150': 147
+        };
+
+        __baseUrl = Browser.getProtocol() + '//fastlane.rubiconproject.com/a/api/fastlane.json';
+
+        __baseClass = Partner(__profile, configs, null, {
+            parseResponse: __parseResponse,
+            generateRequestObj: __generateRequestObj
+        });
+    })();
+
+    /* =====================================
+     * Public Interface
+     * ---------------------------------- */
+
+    var derivedClass = {
+        /* Class Information
+         * ---------------------------------- */
+
+        //? if (DEBUG) {
+        __type__: 'RubiconModule',
+        //? }
+
+        //? if (TEST) {
+        __baseClass: __baseClass,
+        //? }
+
+        /* Data
+         * ---------------------------------- */
+
+        //? if (TEST) {
+        __profile: __profile,
+        __baseUrl: __baseUrl,
+        //? }
+
+        /* Functions
+         * ---------------------------------- */
+
+        setFirstPartyData: setFirstPartyData,
+
+        //? if (TEST) {
+        __parseResponse: __parseResponse,
+        __generateRequestObj: __generateRequestObj
+        //? }
+    };
+
+    return Classify.derive(__baseClass, derivedClass);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Exports /////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+module.exports = RubiconModule;


### PR DESCRIPTION
@ix-certification , here is an update of the Rubicon Adapter:

The target would be to move all the account to use the standard LineItemTypes config and not custom. The goal is to migrate all current account so line items used by DFP will now target ix_rubi_om = targetingCpm. It will make the setup easier, with less potential error and make all bidders compete on same granularity.

PR checklist:
1- Check that all the following files are complete and up-to-date: OK
2- Check that your adapter version number is up-to-date: OK
3- Check that bidder documentation is up-to-date: OK
4- Check that your CHANGES.md file is up-to-date: OK
5- Run the linter: OK
6- Run the system tests: OK

Also as discussed previously could you please:

* move one publisher to the new adapter and inform us so we can check all the data looks ok.
* then if all ok, migrate globally with a specific date and hours (if we need to rollback).
* inform Rubicon when a client is switched from the "custom" to "standard" lineItemType and used the new IX line items.

Here is a proposal migration plan for switching the lineItemType:

Step 1 - IX creates standard line items
Step 2 - IX switches Rubicon lineItemTypes configuration to STANDARD
Step 3 - IX and RP teams monitor for drops in performance
Step 4 - Confirm that performance is healthy
Step 5 - IX removes old Rubicon line items


Let me know if you have any questions,
